### PR TITLE
Removed node version 10.x

### DIFF
--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -16,7 +16,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [10.x, 12.x, 14.x]
+        node-version: [12.x, 14.x]
 
     steps:
     - uses: actions/checkout@v2


### PR DESCRIPTION
When working with Typescript, target `ES3` has been deprecated. I made the target `ES5`. We, therefore, do not need to run against node version 10.x. Since we are under `ES5` I started using newer array methods, like `includes`.